### PR TITLE
Use COPY instead of ADD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d && \
     service nginx stop && \
     rm -rf /var/lib/apt/lists/*
 
-ADD config /app/onlyoffice/setup/config/
-ADD run-document-server.sh /app/onlyoffice/run-document-server.sh
+COPY config /app/onlyoffice/setup/config/
+COPY run-document-server.sh /app/onlyoffice/run-document-server.sh
 
 EXPOSE 80 443
 


### PR DESCRIPTION
According to https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy
It's prefered to use COPY if no need to extract tars