### PR TITLE
Define '**' behavior explicitly

### DIFF
--- a/run-document-server.sh
+++ b/run-document-server.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Define '**' behavior explicitly
+shopt -s globstar
+
 APP_DIR="/var/www/onlyoffice/documentserver"
 DATA_DIR="/var/www/onlyoffice/Data"
 LOG_DIR="/var/log/onlyoffice"


### PR DESCRIPTION
If globstar is set and  if the pattern '**' is followed by a ‘/’, only directories and subdirectories match.