### PR TITLE
According to openshift dev team

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,4 +72,4 @@ RUN echo "$REPO_URL" | tee /etc/apt/sources.list.d/onlyoffice.list && \
 
 VOLUME /var/log/onlyoffice /var/lib/onlyoffice /var/www/onlyoffice/Data /var/lib/postgresql /usr/share/fonts/truetype/custom
 
-CMD bash -C '/app/onlyoffice/run-document-server.sh';'bash'
+CMD bash -C '/app/onlyoffice/run-document-server.sh';'ping 127.0.0.1'


### PR DESCRIPTION
>we need to have a process that runs in a foreground, otherwise OpenShift will automatically shutdown container without running foreground process.