### PR TITLE
Fix issue #92

### DIFF
--- a/run-document-server.sh
+++ b/run-document-server.sh
@@ -302,6 +302,8 @@ if [ ${ONLYOFFICE_DATA_CONTAINER_HOST} = "localhost" ]; then
     update_rabbitmq_setting
   else
     LOCAL_SERVICES+=("rabbitmq-server")
+    # allow Rabbitmq startup after container kill
+    rm -rf /var/run/rabbitmq
   fi
 
   if [ ${REDIS_SERVER_HOST} != "localhost" ]; then


### PR DESCRIPTION
Thanks to @snorre-k
See:
https://github.com/ONLYOFFICE/Docker-DocumentServer/issues/92#issuecomment-431655508
In short - on some Linux system (Ubuntu at least)
it container stopped - /var/run/rabbitmq dir is not cleared up.
Need to manually clear it on start.