### PR TITLE
fix issue #96 ; 'Download failed' after upgrade to onlyoffice 

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ Below is the complete list of parameters that can be set using environment varia
 - **SSL_CERTIFICATE_PATH**: The path to the SSL certificate to use. Defaults to `/var/www/onlyoffice/Data/certs/onlyoffice.crt`.
 - **SSL_KEY_PATH**: The path to the SSL certificate's private key. Defaults to `/var/www/onlyoffice/Data/certs/onlyoffice.key`.
 - **SSL_DHPARAM_PATH**: The path to the Diffie-Hellman parameter. Defaults to `/var/www/onlyoffice/Data/certs/dhparam.pem`.
-- **SSL_SELFSIGNED_CERTIFICATE**: Set to `true`if using selfsigned certificates. Defaults to `false`
 - **SSL_VERIFY_CLIENT**: Enable verification of client certificates using the `CA_CERTIFICATES_PATH` file. Defaults to `false`
 - **POSTGRESQL_SERVER_HOST**: The IP address or the name of the host where the PostgreSQL server is running.
 - **POSTGRESQL_SERVER_PORT**: The PostgreSQL server port number.
@@ -177,6 +176,7 @@ Below is the complete list of parameters that can be set using environment varia
 - **JWT_ENABLED**: Specifies the enabling the JSON Web Token validation by the ONLYOFFICE Document Server. Defaults to `false`.
 - **JWT_SECRET**: Defines the secret key to validate the JSON Web Token in the request to the ONLYOFFICE Document Server. Defaults to `secret`.
 - **JWT_HEADER**: Defines the http header that will be used to send the JSON Web Token. Defaults to `Authorization`.
+- **REJECT_UNAUTHORIZED_STORAGE**: Set to `true`if using selfsigned certificates for your storage server e.g. Nextcloud. Defaults to `false`
 
 ## Installing ONLYOFFICE Document Server integrated with Community and Mail Servers
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Below is the complete list of parameters that can be set using environment varia
 - **SSL_CERTIFICATE_PATH**: The path to the SSL certificate to use. Defaults to `/var/www/onlyoffice/Data/certs/onlyoffice.crt`.
 - **SSL_KEY_PATH**: The path to the SSL certificate's private key. Defaults to `/var/www/onlyoffice/Data/certs/onlyoffice.key`.
 - **SSL_DHPARAM_PATH**: The path to the Diffie-Hellman parameter. Defaults to `/var/www/onlyoffice/Data/certs/dhparam.pem`.
+- **SSL_SELFSIGNED_CERTIFICATE**: Set to `true`if using selfsigned certificates. Defaults to `false`
 - **SSL_VERIFY_CLIENT**: Enable verification of client certificates using the `CA_CERTIFICATES_PATH` file. Defaults to `false`
 - **POSTGRESQL_SERVER_HOST**: The IP address or the name of the host where the PostgreSQL server is running.
 - **POSTGRESQL_SERVER_PORT**: The PostgreSQL server port number.

--- a/run-document-server.sh
+++ b/run-document-server.sh
@@ -21,7 +21,7 @@ SSL_KEY_PATH=${SSL_KEY_PATH:-${SSL_CERTIFICATES_DIR}/onlyoffice.key}
 CA_CERTIFICATES_PATH=${CA_CERTIFICATES_PATH:-${SSL_CERTIFICATES_DIR}/ca-certificates.pem}
 SSL_DHPARAM_PATH=${SSL_DHPARAM_PATH:-${SSL_CERTIFICATES_DIR}/dhparam.pem}
 SSL_VERIFY_CLIENT=${SSL_VERIFY_CLIENT:-off}
-SSL_SELFSIGNED_CERTIFICATE=${SSL_SELFSIGNED_CERTIFICATE:-false}
+REJECT_UNAUTHORIZED_STORAGE=${REJECT_UNAUTHORIZED_STORAGE:-false}
 ONLYOFFICE_HTTPS_HSTS_ENABLED=${ONLYOFFICE_HTTPS_HSTS_ENABLED:-true}
 ONLYOFFICE_HTTPS_HSTS_MAXAGE=${ONLYOFFICE_HTTPS_HSTS_MAXAGE:-31536000}
 SYSCONF_TEMPLATES_DIR="/app/onlyoffice/setup/config"
@@ -286,7 +286,7 @@ update_nginx_settings(){
       sed '/max-age=/d' -i ${NGINX_ONLYOFFICE_CONF}
     fi
 
-    if [ "${SSL_SELFSIGNED_CERTIFICATE}" == "true" ]; then
+    if [ "${REJECT_UNAUTHORIZED_STORAGE}" == "true" ]; then
       ${JSON} -I -e "if(this.services.CoAuthoring.requestDefaults===undefined)this.services.CoAuthoring.requestDefaults={}"
       ${JSON} -I -e "if(this.services.CoAuthoring.requestDefaults.rejectUnauthorized===undefined)this.services.CoAuthoring.requestDefaults.rejectUnauthorized=false"
     fi

--- a/run-document-server.sh
+++ b/run-document-server.sh
@@ -21,6 +21,7 @@ SSL_KEY_PATH=${SSL_KEY_PATH:-${SSL_CERTIFICATES_DIR}/onlyoffice.key}
 CA_CERTIFICATES_PATH=${CA_CERTIFICATES_PATH:-${SSL_CERTIFICATES_DIR}/ca-certificates.pem}
 SSL_DHPARAM_PATH=${SSL_DHPARAM_PATH:-${SSL_CERTIFICATES_DIR}/dhparam.pem}
 SSL_VERIFY_CLIENT=${SSL_VERIFY_CLIENT:-off}
+SSL_SELFSIGNED_CERTIFICATE=${SSL_SELFSIGNED_CERTIFICATE:-false}
 ONLYOFFICE_HTTPS_HSTS_ENABLED=${ONLYOFFICE_HTTPS_HSTS_ENABLED:-true}
 ONLYOFFICE_HTTPS_HSTS_MAXAGE=${ONLYOFFICE_HTTPS_HSTS_MAXAGE:-31536000}
 SYSCONF_TEMPLATES_DIR="/app/onlyoffice/setup/config"
@@ -283,6 +284,11 @@ update_nginx_settings(){
       sed 's,\(max-age=\).*\(;\)$,'"\1${ONLYOFFICE_HTTPS_HSTS_MAXAGE}\2"',' -i ${NGINX_ONLYOFFICE_CONF}
     else
       sed '/max-age=/d' -i ${NGINX_ONLYOFFICE_CONF}
+    fi
+
+    if [ "${SSL_SELFSIGNED_CERTIFICATE}" == "true" ]; then
+      ${JSON} -I -e "if(this.services.CoAuthoring.requestDefaults===undefined)this.services.CoAuthoring.requestDefaults={}"
+      ${JSON} -I -e "if(this.services.CoAuthoring.requestDefaults.rejectUnauthorized===undefined)this.services.CoAuthoring.requestDefaults.rejectUnauthorized=false"
     fi
   else
     ln -sf ${NGINX_ONLYOFFICE_PATH}/ds.conf.tmpl ${NGINX_ONLYOFFICE_CONF}


### PR DESCRIPTION
Added $SSL_SELFSIGNED_CERTIFICATE to docker environment variables to set CoAuthoring.requestDefaults.rejectUnauthorized in /etc/onlyoffice/documentserver/local.json if using a selfsigned certificate.