### PR TITLE
Use netcat-openbsd for IPv6 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d && \
         mysql-client \
         nano \
         net-tools \
-        netcat \
+        netcat-openbsd \
         nginx-extras \
         postgresql \
         postgresql-client \


### PR DESCRIPTION
The traditional netcat package does not support IPv6, and the connection check will fail if the RabbitMQ host is IPv6-only with the following error:

```
rabbitmq: forward host lookup failed: No address associated with name
```