### PR TITLE
Initialliaze services.CoAuthoring.redis before setting a child to a value

### DIFF
--- a/run-document-server.sh
+++ b/run-document-server.sh
@@ -284,6 +284,7 @@ update_rabbitmq_setting(){
 }
 
 update_redis_settings(){
+  ${JSON} -I -e "if(this.services.CoAuthoring.redis===undefined)this.services.CoAuthoring.redis={};"
   ${JSON} -I -e "this.services.CoAuthoring.redis.host = '${REDIS_SERVER_HOST}'"
   ${JSON} -I -e "this.services.CoAuthoring.redis.port = '${REDIS_SERVER_PORT}'"
 }


### PR DESCRIPTION
Solves https://github.com/ONLYOFFICE/Docker-DocumentServer/issues/271