### PR TITLE
Merge branch hotfix/v7.0.1 into release/v7.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ sudo docker run --init --net onlyoffice --privileged -i -t -d --restart=always -
  onlyoffice/mailserver
 ```
 
-The additional parameters for mail server are available [here](https://github.com/ONLYOFFICE/Docker-CommunityServer/blob/master/docker-compose.yml#L75).
+The additional parameters for mail server are available [here](https://github.com/ONLYOFFICE/Docker-CommunityServer/blob/master/docker-compose.workspace_enterprise.yml#L87).
 
 To learn more, refer to the [ONLYOFFICE Mail Server documentation](https://github.com/ONLYOFFICE/Docker-MailServer "ONLYOFFICE Mail Server documentation").
 
@@ -295,7 +295,7 @@ bash opensource-install.sh -md yourdomain.com
 Or, use [docker-compose](https://docs.docker.com/compose/install "docker-compose"). For the mail server correct work you need to specify its hostname 'yourdomain.com'. Assuming you have docker-compose installed, execute the following command:
 
 ```bash
-wget https://raw.githubusercontent.com/ONLYOFFICE/Docker-CommunityServer/master/docker-compose.yml
+wget https://raw.githubusercontent.com/ONLYOFFICE/Docker-CommunityServer/master/docker-compose.groups.yml
 docker-compose up -d
 ```
 


### PR DESCRIPTION
Continue of #400

Those links became incorrect in
https://github.com/ONLYOFFICE/Docker-CommunityServer/commit/e7c8e59a37a736c7b1dd79664b01f2e4b43b1479

I'm not sure that we REALLY need those links in this project, maybe just
give links to README page and that's it
But leaving it as it is