### PR TITLE
Fix update_ds_settings() in entrypoint

### DIFF
--- a/run-document-server.sh
+++ b/run-document-server.sh
@@ -298,9 +298,9 @@ update_redis_settings(){
 }
 
 update_ds_settings(){
-  ${JSON} -I -e "this.services.CoAuthoring.token.enable.browser = ${JWT_ENABLED}"
-  ${JSON} -I -e "this.services.CoAuthoring.token.enable.request.inbox = ${JWT_ENABLED}"
-  ${JSON} -I -e "this.services.CoAuthoring.token.enable.request.outbox = ${JWT_ENABLED}"
+  ${JSON} -I -e "this.services.CoAuthoring.token.enable.browser = '${JWT_ENABLED}'"
+  ${JSON} -I -e "this.services.CoAuthoring.token.enable.request.inbox = '${JWT_ENABLED}'"
+  ${JSON} -I -e "this.services.CoAuthoring.token.enable.request.outbox = '${JWT_ENABLED}'"
 
   ${JSON} -I -e "this.services.CoAuthoring.secret.inbox.string = '${JWT_SECRET}'"
   ${JSON} -I -e "this.services.CoAuthoring.secret.outbox.string = '${JWT_SECRET}'"
@@ -309,11 +309,11 @@ update_ds_settings(){
   ${JSON} -I -e "this.services.CoAuthoring.token.inbox.header = '${JWT_HEADER}'"
   ${JSON} -I -e "this.services.CoAuthoring.token.outbox.header = '${JWT_HEADER}'"
 
-  ${JSON} -I -e "this.services.CoAuthoring.token.inbox.inBody = ${JWT_IN_BODY}"
-  ${JSON} -I -e "this.services.CoAuthoring.token.outbox.inBody = ${JWT_IN_BODY}"
+  ${JSON} -I -e "this.services.CoAuthoring.token.inbox.inBody = '${JWT_IN_BODY}'"
+  ${JSON} -I -e "this.services.CoAuthoring.token.outbox.inBody = '${JWT_IN_BODY}'"
 
   if [ -f "${ONLYOFFICE_EXAMPLE_CONFIG}" ]; then
-    ${JSON_EXAMPLE} -I -e "this.server.token.enable = ${JWT_ENABLED}"
+    ${JSON_EXAMPLE} -I -e "this.server.token.enable = '${JWT_ENABLED}'"
     ${JSON_EXAMPLE} -I -e "this.server.token.secret = '${JWT_SECRET}'"
     ${JSON_EXAMPLE} -I -e "this.server.token.authorizationHeader = '${JWT_HEADER}'"
   fi


### PR DESCRIPTION
## Bug:
Setting `JWT_ENABLED` and/or `JWT_IN_BODY` to true have no effect as evident by `/etc/onlyoffice/documentserver/local.json` still showing false for relevant fields. (setting `JWT_IN_BODY` to true causes an undefined error in logs)

## Podman note:
I also commented out the following lines as podman uses `True` instead of `true`
```
# validate user's vars before usinig in json
if [ "${JWT_ENABLED}" == "true" ]; then
  JWT_ENABLED="true"
else
  JWT_ENABLED="false"
fi
```

## Test/workaround:
Mount the modified file into `/app/ds/run-document-server.sh`