### PR TITLE
Enable autoassembly using env variables

### DIFF
--- a/run-document-server.sh
+++ b/run-document-server.sh
@@ -77,6 +77,9 @@ NGINX_WORKER_CONNECTIONS=${NGINX_WORKER_CONNECTIONS:-$(ulimit -n)}
 
 JWT_ENABLED=${JWT_ENABLED:-true}
 
+AUTO_ASSEMBLY_ENABLED=${AUTO_ASSEMBLY_ENABLED:-false}
+AUTO_ASSEMBLY_INTERVAL=${AUTO_ASSEMBLY_INTERVAL:-20m}
+
 # validate user's vars before usinig in json
 if [ "${JWT_ENABLED}" == "true" ]; then
   JWT_ENABLED="true"
@@ -342,6 +345,12 @@ update_ds_settings(){
   if [ "${WOPI_ENABLED}" == "true" ]; then
     ${JSON} -I -e "if(this.wopi===undefined)this.wopi={}"
     ${JSON} -I -e "this.wopi.enable = true"
+  fi
+    
+  if [ "${AUTO_ASSEMBLY_ENABLED}" == "true" ]; then
+    ${JSON} -I -e "if(this.services.CoAuthoring.autoAssembly===undefined)this.services.CoAuthoring.autoAssembly={};"
+    ${JSON} -I -e "this.services.CoAuthoring.autoAssembly.enable = true"
+    ${JSON} -I -e "this.services.CoAuthoring.autoAssembly.interval = '${AUTO_ASSEMBLY_INTERVAL}'"
   fi
 }
 


### PR DESCRIPTION
Add option to use environment variables to enable autoassembly on the docker:
- `AUTO_ASSEMBLY_ENABLED` set to `true` (default: `false`)
- `AUTO_ASSEMBLY_INTERVAL` can be set (default: `20m`)

This option can be useful for use of OnlyOffice with Nextcloud