### PR TITLE
Generated JWT secret is too small for HMAC SHA256

### DIFF
--- a/run-document-server.sh
+++ b/run-document-server.sh
@@ -87,7 +87,7 @@ fi
 
 [ -z $JWT_SECRET ] && JWT_MESSAGE='JWT is enabled by default. A random secret is generated automatically. Run the command "docker exec $(sudo docker ps -q) sudo documentserver-jwt-status.sh" to get information about JWT.'
 
-JWT_SECRET=${JWT_SECRET:-$(pwgen -s 20)}
+JWT_SECRET=${JWT_SECRET:-$(pwgen -s 32)}
 JWT_HEADER=${JWT_HEADER:-Authorization}
 JWT_IN_BODY=${JWT_IN_BODY:-false}
 


### PR DESCRIPTION
The key that is automatically generated weaken the security strength. As noted in [RFC7518 section 3.2](https://www.rfc-editor.org/rfc/rfc7518.html#section-3.2):
```
A key of the same size as the hash output (for instance, 256 bits for
"HS256") or larger MUST be used with this algorithm.  (This
requirement is based on Section 5.3.4 (Security Effect of the HMAC
Key) of NIST SP 800-117 [NIST.800-107], which states that the
effective security strength is the minimum of the security strength
of the key and two times the size of the internal hash value.)
```

Some JWT libraries are rejecting by default keys that are too small in a attempt to prevent misusages so generating a key that does not respect the minimal length can be problematic for OO integrations.

See #557 for the initial PR.