### PR TITLE
Add new stable images versioning principles

### DIFF
--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -8,6 +8,11 @@ on:
         description: 'Tag for release (ex. 1.2.3.45)'
         type: string
         required: true
+      release_number:
+        description: 'Sequence number of the release (ex. x.x.x.<number>)'
+        type: string
+        required: true
+        default: '1'
 
 env:
   COMPANY_NAME: "onlyoffice"
@@ -42,10 +47,12 @@ jobs:
         run: |
           set -eux
           VERSION=${{ github.event.inputs.tag }}
+          RELEASE_NUMBER=${{ github.event.inputs.release_number }}
           PRODUCT_EDITION=${{ matrix.edition }}
           TESTING_IMAGE=${COMPANY_NAME}/4testing-${PRODUCT_NAME}${PRODUCT_EDITION}
             export PRODUCT_EDITION
-            export TAG=${VERSION}
+            export PULL_TAG=${VERSION}
+            export TAG=${VERSION%.*}.${RELEASE_NUMBER}
             export SHORTER_TAG=${VERSION%.*}
             export SHORTEST_TAG=${VERSION%.*.*}
             docker buildx bake -f docker-bake.hcl ${{ matrix.images }} --push
@@ -82,8 +89,11 @@ jobs:
       - name: build image
         run: |
           set -eux
+          VERSION=${{ github.event.inputs.tag }}
+          RELEASE_NUMBER=${{ github.event.inputs.release_number }}
+          export PULL_TAG=${VERSION}
           export PRODUCT_EDITION=${{ matrix.edition }}
-          export TAG=${{ github.event.inputs.tag }}
+          export TAG=${VERSION%.*}.${RELEASE_NUMBER}
           docker buildx bake -f docker-bake.hcl ${{ matrix.images }} --push
         shell: bash
 
@@ -113,12 +123,14 @@ jobs:
       - name: build UCS
         run: |
            set -eux
+           VERSION=${{ github.event.inputs.tag }}
+           RELEASE_NUMBER=${{ github.event.inputs.release_number }}
            export PRODUCT_EDITION=${{ matrix.edition }}
            export PACKAGE_BASEURL=${{ secrets.REPO_BASEURL }}
            export DOCKERFILE=Dockerfile
            export BASE_IMAGE=ubuntu:20.04
            export PG_VERSION=12
-           export TAG=${{ github.event.inputs.tag }}
-           export PACKAGE_VERSION=$( echo ${TAG} |  sed -E 's/(.*)\./\1-/')
+           export TAG=${VERSION%.*}.${RELEASE_NUMBER}
+           export PACKAGE_VERSION=$( echo ${VERSION} |  sed -E 's/(.*)\./\1-/')
            docker buildx bake -f docker-bake.hcl documentserver-ucs --push
         shell: bash

--- a/.github/workflows/stable-build.yml
+++ b/.github/workflows/stable-build.yml
@@ -91,7 +91,7 @@ jobs:
           set -eux
           VERSION=${{ github.event.inputs.tag }}
           RELEASE_NUMBER=${{ github.event.inputs.release_number }}
-          export PULL_TAG=${VERSION}
+          export PULL_TAG=${VERSION%.*}.${RELEASE_NUMBER}
           export PRODUCT_EDITION=${{ matrix.edition }}
           export TAG=${VERSION%.*}.${RELEASE_NUMBER}
           docker buildx bake -f docker-bake.hcl ${{ matrix.images }} --push

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -10,6 +10,10 @@ variable "SHORTEST_TAG" {
     default = ""
 }
 
+variable "PULL_TAG" {
+    default = ""
+}
+
 variable "COMPANY_NAME" {
     default = ""
 }
@@ -90,7 +94,7 @@ target "documentserver-stable" {
             equal("-ee",PRODUCT_EDITION) ? "docker.io/${COMPANY_NAME}4enterprise/${PREFIX_NAME}${PRODUCT_NAME}${PRODUCT_EDITION}:${TAG}": "",]
     platforms = ["linux/amd64", "linux/arm64"]
     args = {
-        "TAG": "${TAG}"
+        "PULL_TAG": "${PULL_TAG}"
         "COMPANY_NAME": "${COMPANY_NAME}"
         "PRODUCT_NAME": "${PRODUCT_NAME}"
         "PRODUCT_EDITION": "${PRODUCT_EDITION}"
@@ -121,7 +125,7 @@ target "documentserver-nonexample" {
     tags = [ "docker.io/${COMPANY_NAME}/${PRODUCT_NAME}${PREFIX_NAME}${PRODUCT_EDITION}:${TAG}-nonexample" ]
     platforms = ["linux/amd64", "linux/arm64"]
     args = {
-        "TAG": "${TAG}"
+        "PULL_TAG": "${PULL_TAG}"
         "COMPANY_NAME": "${COMPANY_NAME}"
         "PRODUCT_NAME": "${PRODUCT_NAME}"
         "PRODUCT_EDITION": "${PRODUCT_EDITION}"

--- a/production.dockerfile
+++ b/production.dockerfile
@@ -1,15 +1,15 @@
 ### Arguments avavlivable only for FROM instruction ### 
-ARG TAG=latest
+ARG PULL_TAG=latest
 ARG COMPANY_NAME=onlyoffice
 ARG PRODUCT_EDITION=
 
 ### Build main-release ###
 
-FROM ${COMPANY_NAME}/4testing-documentserver${PRODUCT_EDITION}:${TAG} as documentserver-stable
+FROM ${COMPANY_NAME}/4testing-documentserver${PRODUCT_EDITION}:${PULL_TAG} as documentserver-stable
 
 ### Build nonexample ###
  
-FROM ${COMPANY_NAME}/documentserver${PRODUCT_EDITION}:${TAG} as documentserver-nonexample
+FROM ${COMPANY_NAME}/documentserver${PRODUCT_EDITION}:${PULL_TAG} as documentserver-nonexample
 
 ARG COMPANY_NAME=onlyoffice
 ARG PRODUCT_NAME=documentserver


### PR DESCRIPTION
The new principle of stable docker images versioning: release numbering is now not by build number, but by serial number.