### PR TITLE
Add the ability to rebuild images

### DIFF
--- a/.github/workflows/cron-rebuild-trigger.yml
+++ b/.github/workflows/cron-rebuild-trigger.yml
@@ -1,0 +1,23 @@
+---
+name: Trigger 4testing rebuild
+
+run-name: "Weekly 4testing rebuild trigger"
+
+on: 
+  schedule:
+    # Run every Saturday at 10 p.m.   
+    - cron: '00 22 * * 6'
+  
+jobs: 
+  trigger-rebuild:
+    name: "trigget-rebuild"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Rebuild 4testing manualy
+        env: 
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          gh workflow run rebuild.yml \
+              --repo ONLYOFFICE/Docker-DocumentServer \
+              -f repo=4test \
+              -f quantity=1 

--- a/.github/workflows/cron-rebuild-trigger.yml
+++ b/.github/workflows/cron-rebuild-trigger.yml
@@ -19,5 +19,4 @@ jobs:
         run: |
           gh workflow run rebuild.yml \
               --repo ONLYOFFICE/Docker-DocumentServer \
-              -f repo=4test \
-              -f quantity=1 
+              -f repo=4test

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -117,6 +117,11 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2      
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
      # Determines the new build number based 
      # on data from the hub.docker registry
       - name: Declare release number
@@ -174,6 +179,11 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       # Determines the new build number based 
       # on data from the hub.docker registry
       - name: Declare release number

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -5,8 +5,6 @@ run-name: >
         Rebuild DocumentServer with secure updates for repo: ${{ github.event.inputs.repo }}
 
 on:
-  # Push trigger is disabled now.
-  # push:
   workflow_dispatch:
     inputs:
       repo:

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -1,0 +1,209 @@
+---
+name: Rebuild Docker-Documentserver 
+
+run-name: "Rebuild images for repo: ${{ github.event.inputs.repo }}"
+
+on:
+  # Push trigger is disabled now.
+  # push:
+  workflow_dispatch:
+    inputs:
+      repo:
+        type: choice
+        description: Please, choose upload repo..
+        options:
+        - '4test'
+        - 'stable'
+      quantity: 
+        type: string
+        description: 'How many recent releases should be rebuilt? last 1 by default'
+        required: true
+        default: '1'
+
+permissions:
+  # All other permissions are set to none
+  contents: read
+  # Technically read access while waiting for images should be more than enough. However,
+  # there is a bug in GitHub Actions/Packages and in case private repositories are used, you get a permission
+  # denied error when attempting to just pull private image, changing the token permission to write solves the
+  # issue. This is not dangerous, because if it is for "ONLYOFFICE/Docker-DocumentServer", only maintainers can use ds-rebuild.yaml
+  # If it is for a fork, then the token is read-only anyway.
+  packages: read
+
+env:
+  REPO:  ${{ github.event.inputs.repo }} 
+  COMPANY_NAME: "onlyoffice"
+  PRODUCT_NAME: "documentserver" 
+  REGISTRY_URL: "https://hub.docker.com/v2/repositories"  
+
+jobs:
+  rebuild-info:
+    name: "Rebuild-info"
+    runs-on: "ubuntu-22.04"
+    outputs: 
+      stable-versions: ${{ steps.selective-checks.outputs.stable-versions }}
+      ucs-versions: ${{ steps.selective-checks.outputs.ucs-versions }}
+      minor-tags: ${{ steps.selective-checks.outputs.minor-tags }}
+      ucs-rebuild-condition: ${{ steps.selective-checks.outputs.ucs-rebuild-condition }}
+      prefix-name: ${{ steps.selective-checks.outputs.prefix-name }}
+    steps:
+      - name: Selective checks
+        id: selective-checks
+        env: 
+          QUANTITY: ${{ github.event.inputs.quantity }}
+        run: |
+            set -e
+            if [ "${REPO}" == "stable" ]; then
+                 UCS_REBUILD=true
+                 UCS_VERSIONS=($(curl -s -H -X ${REGISTRY_URL}/${COMPANY_NAME}/${PRODUCT_NAME}-ucs/tags/?page_size=100 | \
+                            jq -r '.results|.[]|.name' | grep -m${QUANTITY} -Eo '[0-9]{1,}.[0-9]{1,}.[0-9]{1,}.1' || true))
+                 echo "ucs-versions=$(jq -c -n '$ARGS.positional' --args "${UCS_VERSIONS[@]}")" >> "$GITHUB_OUTPUT"
+            else 
+                 UCS_REBUILD=false
+                 PREFIX_NAME=4testing-
+            fi
+            
+            STABLE_VERSIONS=($(curl -s -H -X ${REGISTRY_URL}/${COMPANY_NAME}/${PRODUCT_NAME}/tags/?page_size=100 | \
+                            jq -r '.results|.[]|.name' | grep -m${QUANTITY} -Eo '[0-9]{1,}.[0-9]{1,}.[0-9]{1,}.1' || true))
+                            
+            # When rebuilding stable versions of the document server, 
+            # it is necessary to determine the version from which the 
+            # minor x.x tag will need to be pushed.        
+            
+            VERSIONS=(${STABLE_VERSIONS[@]})
+            for i in {1..10}; do
+                 if [ -z "${VERSIONS}" ]; then
+                     break
+                 else 
+                     TEMPLATE=${VERSIONS[0]%.*.*}
+                     TEMPLATE_MINOR=$(printf -- '%s\n' "${VERSIONS[@]}" | grep -o -m 1 "${VERSIONS[0]%.*.*}.[0-9].[0-9]")
+                     MINOR_TAGS+=(${TEMPLATE_MINOR%.*})
+            
+                     for v in ${MINOR_TAGS[@]}; do
+                          VERSIONS=(${VERSIONS[@]//${v%.*}.*.*})
+                     done
+                 fi
+            done
+            
+            echo "Stable releases that will be rebuilded"
+            echo "--------------------------------------"
+            echo "${STABLE_VERSIONS[@]}"
+            echo
+            echo 
+            echo "Ucs releases that will be rebuilded"
+            echo "-----------------------------------"
+            echo "${UCS_VERSIONS[@]}"
+            
+            echo "stable-versions=$(jq -c -n '$ARGS.positional' --args "${STABLE_VERSIONS[@]}")" >> "$GITHUB_OUTPUT"
+            echo "minor-tags=${MINOR_TAGS[@]}" >> "$GITHUB_OUTPUT"
+            echo "ucs-rebuild-condition=${UCS_REBUILD}" >> "$GITHUB_OUTPUT"
+            echo "prefix-name=${PREFIX_NAME}" >>  "$GITHUB_OUTPUT"
+        shell: bash
+
+  re-build-stable:
+    name: "Rebuild stable:${{ matrix.version }} ${{ matrix.edition }}"
+    needs: [rebuild-info]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        type: ["stable"]
+        edition: ["", "-ee", "-de"]
+        version: ${{fromJSON(needs.rebuild-info.outputs.stable-versions)}}
+    steps:
+      - name: Checkout code 
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2      
+     # Determines the new build number based 
+     # on data from the hub.docker registry
+      - name: Declare release number
+        id: release-number
+        env: 
+          REBUILD_VERSION: ${{ matrix.version }}
+        run: |
+          MINOR_VERSION=${REBUILD_VERSION%.*} 
+          LAST_RELEASE=$(curl -s -H -X ${REGISTRY_URL}/${COMPANY_NAME}/${PRODUCT_NAME}/tags/?page_size=100 \
+          | jq -r '.results|.[]|.name' | grep -Eo -m1 "${MINOR_VERSION}.[0-9]{1,}")
+          LAST_RELEASE=${LAST_RELEASE#*.*.*.}
+          echo "release-number=$((LAST_RELEASE+1))" >> "$GITHUB_OUTPUT"   
+        shell: bash  
+    #  Note: Rebuilding images with an 
+    #  extra layer to update security and 
+    #  all dependencies. Update tags got +1 to previous release.
+      - name: Re-build documentserver-stable
+        env:
+          MINOR_TAGS: ${{ needs.rebuild-info.outputs.minor-tags }}
+          VERSION: ${{ matrix.version }}
+          RELEASE_NUMBER: ${{ steps.release-number.outputs.release-number }}
+          PREFIX_NAME: ${{ needs.rebuild-info.outputs.prefix-name }}
+        run: |
+            set -eux
+            export PRODUCT_EDITION=${{ matrix.edition }}
+            export PULL_TAG=${VERSION%.*}.1
+            export TAG=${VERSION%.*}.${RELEASE_NUMBER}
+            export SHORTER_TAG=${VERSION%.*}
+            export SHORTEST_TAG=${VERSION%.*.*}
+            
+            if [ "${REPO}" == "stable" ]; then
+                 for v in ${MINOR_TAGS[@]}; do
+                     if [ "${SHORTER_TAG}" == "${v}" ]; then
+                         export PUSH_MAJOR="true"
+                     fi
+                 done
+            fi
+            docker buildx bake -f docker-bake.hcl documentserver-stable-rebuild --push
+        shell: bash
+  re-build-ucs:
+    name: "Rebuild ucs: ${{ matrix.version }} ${{ matrix.edition }}"
+    if: needs.rebuild-info.outputs.ucs-rebuild-condition == 'true'
+    needs: [rebuild-info]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        type: ["ucs"]
+        edition: ["", "-ee"]
+        version: ${{fromJSON(needs.rebuild-info.outputs.ucs-versions)}}
+    steps:
+      - name: Checkout code 
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      # Determines the new build number based 
+      # on data from the hub.docker registry
+      - name: Declare release number
+        id: release-number
+        env: 
+          REBUILD_VERSION: ${{ matrix.version }}
+        run: |
+          MINOR_VERSION=${REBUILD_VERSION%.*} 
+          LAST_RELEASE=$(curl -s -H -X ${REGISTRY_URL}/${COMPANY_NAME}/${PRODUCT_NAME}/tags/?page_size=100 \
+                        | jq -r '.results|.[]|.name' | grep -Eo -m1 "${MINOR_VERSION}.[0-9]{1,}")
+          LAST_RELEASE=${LAST_RELEASE#*.*.*.}
+          echo "release-number=$((LAST_RELEASE+1))" >> "$GITHUB_OUTPUT"
+        shell: bash       
+      #  Note: Rebuilding images with an 
+      #  extra layer to update security and 
+      #  all dependencies. Update tags +1 to previous release.
+      - name: Re-build documentserver-ucs
+        env: 
+          VERSION: ${{ matrix.version }}
+          RELEASE_NUMBER: ${{ steps.release-number.outputs.release-number }}
+        run: |
+            set -eux
+            export PRODUCT_EDITION=${{ matrix.edition }}        
+            export PULL_TAG=${VERSION%.*}.1
+            export TAG=${VERSION%.*}.${RELEASE_NUMBER}
+            export SHORTER_TAG=${VERSION%.*}
+            export SHORTEST_TAG=${VERSION%.*.*}
+          
+            export UCS_REBUILD=true
+            export UCS_PREFIX=-ucs
+          
+            docker buildx bake -f docker-bake.hcl documentserver-stable-rebuild --push
+        shell: bash

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -1,7 +1,8 @@
 ---
 name: Rebuild Docker-Documentserver 
 
-run-name: "Rebuild images for repo: ${{ github.event.inputs.repo }}"
+run-name: >
+        Rebuild DocumentServer with secure updates for repo: ${{ github.event.inputs.repo }}
 
 on:
   # Push trigger is disabled now.
@@ -30,8 +31,7 @@ permissions:
   # If it is for a fork, then the token is read-only anyway.
   packages: read
 
-env:
-  REPO:  ${{ github.event.inputs.repo }} 
+env: 
   COMPANY_NAME: "onlyoffice"
   PRODUCT_NAME: "documentserver" 
   REGISTRY_URL: "https://hub.docker.com/v2/repositories"  
@@ -40,25 +40,33 @@ jobs:
   rebuild-info:
     name: "Rebuild-info"
     runs-on: "ubuntu-22.04"
+    env:
+      REPO_INPUTS: ${{ github.event.inputs.repo }}
+      QUANTITY_INPUTS: ${{ github.event.inputs.quantity }}
+      EVENT: ${{ github.event_name }}
     outputs: 
       stable-versions: ${{ steps.selective-checks.outputs.stable-versions }}
       ucs-versions: ${{ steps.selective-checks.outputs.ucs-versions }}
       minor-tags: ${{ steps.selective-checks.outputs.minor-tags }}
       ucs-rebuild-condition: ${{ steps.selective-checks.outputs.ucs-rebuild-condition }}
       prefix-name: ${{ steps.selective-checks.outputs.prefix-name }}
+      repo: ${{ steps.selective-checks.outputs.repo }}
     steps:
       - name: Selective checks
         id: selective-checks
-        env: 
-          QUANTITY: ${{ github.event.inputs.quantity }}
         run: |
             set -e
+
+            REPO=${REPO_INPUTS:-"4test"}
+            QUANTITY=${QUANTITY_INPUTS:-"1"}
+
             if [ "${REPO}" == "stable" ]; then
                  UCS_REBUILD=true
                  UCS_VERSIONS=($(curl -s -H -X ${REGISTRY_URL}/${COMPANY_NAME}/${PRODUCT_NAME}-ucs/tags/?page_size=100 | \
                             jq -r '.results|.[]|.name' | grep -m${QUANTITY} -Eo '[0-9]{1,}.[0-9]{1,}.[0-9]{1,}.1' || true))
                  echo "ucs-versions=$(jq -c -n '$ARGS.positional' --args "${UCS_VERSIONS[@]}")" >> "$GITHUB_OUTPUT"
-            else 
+            elif
+               [ "${REPO}" == "4test" ]; then 
                  UCS_REBUILD=false
                  PREFIX_NAME=4testing-
             fi
@@ -98,6 +106,7 @@ jobs:
             echo "minor-tags=${MINOR_TAGS[@]}" >> "$GITHUB_OUTPUT"
             echo "ucs-rebuild-condition=${UCS_REBUILD}" >> "$GITHUB_OUTPUT"
             echo "prefix-name=${PREFIX_NAME}" >>  "$GITHUB_OUTPUT"
+            echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
         shell: bash
 
   re-build-stable:
@@ -144,6 +153,7 @@ jobs:
           VERSION: ${{ matrix.version }}
           RELEASE_NUMBER: ${{ steps.release-number.outputs.release-number }}
           PREFIX_NAME: ${{ needs.rebuild-info.outputs.prefix-name }}
+          REPO: ${{ needs.rebuild-info.outputs.repo }}
         run: |
             set -eux
             export PRODUCT_EDITION=${{ matrix.edition }}

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -13,11 +13,6 @@ on:
         options:
         - '4test'
         - 'stable'
-      quantity: 
-        type: string
-        description: 'How many recent releases should be rebuilt? last 1 by default'
-        required: true
-        default: '1'
 
 permissions:
   # All other permissions are set to none
@@ -40,7 +35,6 @@ jobs:
     runs-on: "ubuntu-22.04"
     env:
       REPO_INPUTS: ${{ github.event.inputs.repo }}
-      QUANTITY_INPUTS: ${{ github.event.inputs.quantity }}
       EVENT: ${{ github.event_name }}
     outputs: 
       stable-versions: ${{ steps.selective-checks.outputs.stable-versions }}
@@ -56,12 +50,11 @@ jobs:
             set -e
 
             REPO=${REPO_INPUTS:-"4test"}
-            QUANTITY=${QUANTITY_INPUTS:-"1"}
 
             if [ "${REPO}" == "stable" ]; then
                  UCS_REBUILD=true
                  UCS_VERSIONS=($(curl -s -H -X ${REGISTRY_URL}/${COMPANY_NAME}/${PRODUCT_NAME}-ucs/tags/?page_size=100 | \
-                            jq -r '.results|.[]|.name' | grep -m${QUANTITY} -Eo '[0-9]{1,}.[0-9]{1,}.[0-9]{1,}.1' || true))
+                            jq -r '.results|.[]|.name' | grep -oxE '[0-9]{1,}.[0-9]{1,}.[0-9]{1,}.1' || true))
                  echo "ucs-versions=$(jq -c -n '$ARGS.positional' --args "${UCS_VERSIONS[@]}")" >> "$GITHUB_OUTPUT"
             elif
                [ "${REPO}" == "4test" ]; then 
@@ -70,7 +63,7 @@ jobs:
             fi
             
             STABLE_VERSIONS=($(curl -s -H -X ${REGISTRY_URL}/${COMPANY_NAME}/${PRODUCT_NAME}/tags/?page_size=100 | \
-                            jq -r '.results|.[]|.name' | grep -m${QUANTITY} -Eo '[0-9]{1,}.[0-9]{1,}.[0-9]{1,}.1' || true))
+                            jq -r '.results|.[]|.name' | grep -oxE '[0-9]{1,}.[0-9]{1,}.[0-9]{1,}.1' || true))
                             
             # When rebuilding stable versions of the document server, 
             # it is necessary to determine the version from which the 

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -152,10 +152,10 @@ jobs:
           RELEASE_NUMBER: ${{ steps.release-number.outputs.release-number }}
           PREFIX_NAME: ${{ needs.rebuild-info.outputs.prefix-name }}
           REPO: ${{ needs.rebuild-info.outputs.repo }}
+          PRODUCT_EDITION: ${{ matrix.edition }}
         run: |
             set -eux
-            export PRODUCT_EDITION=${{ matrix.edition }}
-            export PULL_TAG=${VERSION%.*}.1
+            export PULL_TAG=${VERSION}
             export TAG=${VERSION%.*}.${RELEASE_NUMBER}
             export SHORTER_TAG=${VERSION%.*}
             export SHORTEST_TAG=${VERSION%.*.*}
@@ -212,10 +212,10 @@ jobs:
         env: 
           VERSION: ${{ matrix.version }}
           RELEASE_NUMBER: ${{ steps.release-number.outputs.release-number }}
+          PRODUCT_EDITION: ${{ matrix.edition }}
         run: |
             set -eux
-            export PRODUCT_EDITION=${{ matrix.edition }}        
-            export PULL_TAG=${VERSION%.*}.1
+            export PULL_TAG=${VERSION}
             export TAG=${VERSION%.*}.${RELEASE_NUMBER}
             export SHORTER_TAG=${VERSION%.*}
             export SHORTEST_TAG=${VERSION%.*.*}

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -140,7 +140,7 @@ jobs:
     #  all dependencies. Update tags got +1 to previous release.
       - name: Re-build documentserver-stable
         env:
-          MINOR_TAGS: ${{ needs.rebuild-info.outputs.minor-tags }}
+          MINOR_TAGS_ST: ${{ needs.rebuild-info.outputs.minor-tags }}
           VERSION: ${{ matrix.version }}
           RELEASE_NUMBER: ${{ steps.release-number.outputs.release-number }}
           PREFIX_NAME: ${{ needs.rebuild-info.outputs.prefix-name }}
@@ -154,11 +154,15 @@ jobs:
             export SHORTEST_TAG=${VERSION%.*.*}
             
             if [ "${REPO}" == "stable" ]; then
+                 MINOR_TAGS=(${MINOR_TAGS_ST})
                  for v in ${MINOR_TAGS[@]}; do
                      if [ "${SHORTER_TAG}" == "${v}" ]; then
                          export PUSH_MAJOR="true"
                      fi
                  done
+                 if [ "${SHORTER_TAG}" == "${MINOR_TAGS[0]}" ]; then
+                     export LATEST="true"
+                 fi
             fi
             docker buildx bake -f docker-bake.hcl documentserver-stable-rebuild --push
         shell: bash

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -54,6 +54,10 @@ variable "BUILD_CHANNEL" {
     default = ""
 }
 
+variable "PUSH_MAJOR" {
+    default = "false"
+}
+
 ### ↓ Variables for UCS build ↓
 
 variable "BASE_IMAGE" {
@@ -62,6 +66,14 @@ variable "BASE_IMAGE" {
 
 variable "PG_VERSION" {
     default     = ""
+}
+
+variable "UCS_REBUILD" {
+    default = ""
+}
+
+variable "UCS_PREFIX" {
+    default = ""
 }
 
 ### ↑ Variables for UCS build ↑
@@ -130,4 +142,24 @@ target "documentserver-nonexample" {
         "PRODUCT_NAME": "${PRODUCT_NAME}"
         "PRODUCT_EDITION": "${PRODUCT_EDITION}"
     } 
+}
+
+target "documentserver-stable-rebuild" {
+    target = "documentserver-stable-rebuild"
+    dockerfile = "production.dockerfile"
+    tags = equal("true",UCS_REBUILD) ? ["docker.io/${COMPANY_NAME}/${PREFIX_NAME}${PRODUCT_NAME}${PRODUCT_EDITION}-ucs:${TAG}",] : [
+                                        "docker.io/${COMPANY_NAME}/${PREFIX_NAME}${PRODUCT_NAME}${PRODUCT_EDITION}:${TAG}",
+                equal("",PREFIX_NAME) ? "docker.io/${COMPANY_NAME}/${PREFIX_NAME}${PRODUCT_NAME}${PRODUCT_EDITION}:${SHORTER_TAG}": "",
+             equal("true",PUSH_MAJOR) ? "docker.io/${COMPANY_NAME}/${PREFIX_NAME}${PRODUCT_NAME}${PRODUCT_EDITION}:${SHORTEST_TAG}": "",
+                equal("",PREFIX_NAME) ? "docker.io/${COMPANY_NAME}/${PREFIX_NAME}${PRODUCT_NAME}${PRODUCT_EDITION}:latest": "",
+         equal("-ee",PRODUCT_EDITION) && equal("",PREFIX_NAME) ? "docker.io/${COMPANY_NAME}4enterprise/${PREFIX_NAME}${PRODUCT_NAME}${PRODUCT_EDITION}:${TAG}": "",
+                                 ]
+    platforms = ["linux/amd64", "linux/arm64"]
+    args = {
+        "UCS_PREFIX": "${UCS_PREFIX}"
+        "PULL_TAG": "${PULL_TAG}"
+        "COMPANY_NAME": "${COMPANY_NAME}"
+        "PRODUCT_NAME": "${PRODUCT_NAME}"
+        "PRODUCT_EDITION": "${PRODUCT_EDITION}"
+    }
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -58,6 +58,10 @@ variable "PUSH_MAJOR" {
     default = "false"
 }
 
+variable "LATEST" {
+    default = "false"
+}
+
 ### ↓ Variables for UCS build ↓
 
 variable "BASE_IMAGE" {
@@ -151,7 +155,7 @@ target "documentserver-stable-rebuild" {
                                         "docker.io/${COMPANY_NAME}/${PREFIX_NAME}${PRODUCT_NAME}${PRODUCT_EDITION}:${TAG}",
                 equal("",PREFIX_NAME) ? "docker.io/${COMPANY_NAME}/${PREFIX_NAME}${PRODUCT_NAME}${PRODUCT_EDITION}:${SHORTER_TAG}": "",
              equal("true",PUSH_MAJOR) ? "docker.io/${COMPANY_NAME}/${PREFIX_NAME}${PRODUCT_NAME}${PRODUCT_EDITION}:${SHORTEST_TAG}": "",
-                equal("",PREFIX_NAME) ? "docker.io/${COMPANY_NAME}/${PREFIX_NAME}${PRODUCT_NAME}${PRODUCT_EDITION}:latest": "",
+                equal("",PREFIX_NAME) && equal("true",LATEST) ? "docker.io/${COMPANY_NAME}/${PREFIX_NAME}${PRODUCT_NAME}${PRODUCT_EDITION}:latest": "",
          equal("-ee",PRODUCT_EDITION) && equal("",PREFIX_NAME) ? "docker.io/${COMPANY_NAME}4enterprise/${PREFIX_NAME}${PRODUCT_NAME}${PRODUCT_EDITION}:${TAG}": "",
                                  ]
     platforms = ["linux/amd64", "linux/arm64"]

--- a/production.dockerfile
+++ b/production.dockerfile
@@ -2,10 +2,19 @@
 ARG PULL_TAG=latest
 ARG COMPANY_NAME=onlyoffice
 ARG PRODUCT_EDITION=
+### Rebuild arguments
+ARG UCS_PREFIX=
+ARG IMAGE=${COMPANY_NAME}/documentserver${PRODUCT_EDITION}${UCS_PREFIX}:${PULL_TAG}
 
 ### Build main-release ###
 
 FROM ${COMPANY_NAME}/4testing-documentserver${PRODUCT_EDITION}:${PULL_TAG} as documentserver-stable
+
+### Rebuild stable images with secure updates 
+FROM ${IMAGE} as documentserver-stable-rebuild
+RUN    echo "This is rebuild" \
+    && apt-get update -y \
+    && apt-get upgrade -y
 
 ### Build nonexample ###
  


### PR DESCRIPTION
Rebuilding images will be done manually (for now). The choice of the number of rebuilt releases is available (1 by default), the choice of repositories for pushing rebuilt images is available (4testing by default).

Principle of operation:
Through the api of the docker hub, we get the last launched tag that falls under the pattern x.x.x.1, after that the tag with the assembly of which the minor tag x.x will be sent will be calculated. Next, at one of the build steps, the number of the previous release will be received, for example x. x.x.4 which will mean that the current one will be x.x.x.5