### PR TITLE
Merge branch release/v7.5.0 into develop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d && \
         bomstrip \
         certbot \
         curl \
-        gconf-service \
         htop \
         libasound2 \
         libboost-regex-dev \

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
         + [Installation of the SSL Certificates](#installation-of-the-ssl-certificates)
         + [Available Configuration Parameters](#available-configuration-parameters)
 * [Installing ONLYOFFICE Document Server integrated with Community and Mail Servers](#installing-onlyoffice-document-server-integrated-with-community-and-mail-servers)
+* [ONLYOFFICE Document Server ipv6 setup](#onlyoffice-document-server-ipv6-setup)
 * [Issues](#issues)
     - [Docker Issues](#docker-issues)
     - [Document Server usage Issues](#document-server-usage-issues)
@@ -319,6 +320,30 @@ Or, use [docker-compose](https://docs.docker.com/compose/install "docker-compose
 wget https://raw.githubusercontent.com/ONLYOFFICE/Docker-CommunityServer/master/docker-compose.groups.yml
 docker-compose up -d
 ```
+
+## ONLYOFFICE Document Server ipv6 setup
+
+(Works and is supported only for Linux hosts)
+
+Docker does not currently provide ipv6 addresses to containers by default. This function is experimental now.
+
+To set up interaction via ipv6, you need to enable support for this feature in your Docker. For this you need:
+- create the `/etc/docker/daemon.json` file with the following content:
+
+```
+{
+"ipv6": true,
+"fixed-cidr-v6": "2001:db8:abc1::/64"
+}
+```
+- restart docker with the following command: `systemctl restart docker`
+
+After that, all running containers receive an ipv6 address and have an inet6 interface.
+
+You can check your default bridge network and see the field there
+`EnableIPv6=true`. A new ipv6 subnet will also be added.
+
+For more information, visit the official [Docker manual site](https://docs.docker.com/config/daemon/ipv6/)
 
 ## Issues
 


### PR DESCRIPTION
- Add instructions for ipv6 connection. Related to bug #63537 (#654)
- Update README.md
- fix Bug 63804 - Remove gconf from dependencies since it's deprecated (#663)
