### PR TITLE
feat: allow ipfilter configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Below is the complete list of parameters that can be set using environment varia
 - **JWT_HEADER**: Defines the http header that will be used to send the JSON Web Token. Defaults to `Authorization`.
 - **JWT_IN_BODY**: Specifies the enabling the token validation in the request body to the ONLYOFFICE Document Server. Defaults to `false`.
 - **WOPI_ENABLED**: Specifies the enabling the wopi handlers. Defaults to `false`.
+- **IPFILTER_CONFIG**: Sets the `ipfilter` configuration. Must be expressed as a json blob.
 - **ALLOW_META_IP_ADDRESS**: Defines if it is allowed to connect meta IP address or not. Defaults to `false`.
 - **ALLOW_PRIVATE_IP_ADDRESS**: Defines if it is allowed to connect private IP address or not. Defaults to `false`.
 - **USE_UNAUTHORIZED_STORAGE**: Set to `true` if using self-signed certificates for your storage server e.g. Nextcloud. Defaults to `false`

--- a/run-document-server.sh
+++ b/run-document-server.sh
@@ -123,6 +123,7 @@ JWT_HEADER=${JWT_HEADER:-Authorization}
 JWT_IN_BODY=${JWT_IN_BODY:-false}
 
 WOPI_ENABLED=${WOPI_ENABLED:-false}
+IPFILTER_CONFIG=${IPFILTER_CONFIG:-""}
 ALLOW_META_IP_ADDRESS=${ALLOW_META_IP_ADDRESS:-false}
 ALLOW_PRIVATE_IP_ADDRESS=${ALLOW_PRIVATE_IP_ADDRESS:-false}
 
@@ -427,6 +428,10 @@ update_ds_settings(){
   ${JSON} -I -e "this.wopi.modulusOld = '${WOPI_MODULUS}'"
   ${JSON} -I -e "this.wopi.exponent = ${WOPI_EXPONENT}"
   ${JSON} -I -e "this.wopi.exponentOld = ${WOPI_EXPONENT}"
+
+	if [ -n "${IPFILTER_CONFIG}" ]; then
+		${JSON} -I -e "this.ipfilter = '${IPFILTER_CONFIG}'"
+	fi
 
   if [ "${ALLOW_META_IP_ADDRESS}" = "true" ] || [ "${ALLOW_PRIVATE_IP_ADDRESS}" = "true" ]; then
     ${JSON} -I -e "if(this.services.CoAuthoring['request-filtering-agent']===undefined)this.services.CoAuthoring['request-filtering-agent']={}"


### PR DESCRIPTION
This PR allows users to add an IPFILTER_CONFIG environment variable, containing an ipfilter json formatted as shown in the documentation [here](https://helpcenter.onlyoffice.com/docs/installation/docs-configure-ipfilter.aspx), and have it injected into the docker image's configuration 